### PR TITLE
Feature node storage for Graph class (#347)

### DIFF
--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -120,7 +120,7 @@ TEST(GraphTest, FindEdge_Test) {
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge));
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> graph(edgeSet);
-  unsigned long long edgeId = 0;
+  size_t edgeId = 0;
   ASSERT_TRUE(graph.findEdge(&node1,&node2,edgeId));
   CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
 
@@ -683,4 +683,194 @@ TEST(ReverseDirectedGraphTest, test_exception) {
   mixedEdgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> mixedGraph(mixedEdgeSet);
   ASSERT_THROW(mixedGraph.reverseDirectedGraph(), std::runtime_error);
+}
+
+TEST(IsolatedNodeGraphTest, Test_AddNode1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 1);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(IsolatedNodeGraphTest, Test_AddNode2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  graph.addNode(&node4);
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 1);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(TestRemoveNode, Test_isolatedNode) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  // Check the initial number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // We now remove node 5
+  graph.removeNode("5");
+
+  // Check the final number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 2);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(TestRemoveNode, Test_connectedNode) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  // Check the initial number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // We now remove node 2
+  graph.removeNode("2");
+
+  // Check the final number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
+  ASSERT_EQ(graph.getEdgeSet().size(), 1);
+}
+
+TEST(TestGetNode, Test_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  auto node_found = graph.getNode("2");
+  ASSERT_TRUE(node_found.has_value());
+  ASSERT_EQ(node_found.value()->getUserId(), "2");
+
+  auto node_notfound = graph.getNode("5");
+  ASSERT_FALSE(node_notfound.has_value());
+}
+
+TEST(GraphTest, set_data_isolated) {
+  // Create the graph
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedEdge<int> edge1(1, pairNode);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  std::map<std::string, int> initial_values;
+  // Construct map with the initial values of the nodes data
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    initial_values[nodeIt->getUserId()] = nodeIt->getData();
+  }
+  // Change the data contained in the nodes singularly
+  std::map<std::string, int> new_values;
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    int r = std::rand();
+    graph.setNodeData(nodeIt->getUserId(), r);
+    new_values[nodeIt->getUserId()] = r;
+  }
+  // Check the final values of the node data
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    ASSERT_EQ(nodeIt->getData(), new_values[nodeIt->getUserId()]);
+  }
+
+  // Now set the data of all the nodes at once
+  std::map<std::string, int> data_values;
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    int r = std::rand();
+    data_values[nodeIt->getUserId()] = r;
+  }
+  graph.setNodeData(data_values);
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    ASSERT_EQ(nodeIt->getData(), data_values[nodeIt->getUserId()]);
+  }
 }


### PR DESCRIPTION
* Add nodeSet member for Graph class

* Use cached nodeSet in all algorithms

* Add test for graphs with isolated nodes

* Fix typo in overload of addEdge

* Formatting

* Fix type in graphTest

* Delete Edges linked to removed Node in removeNode

* Add more tests for addNode and removeNode methods

* Add test for getNode method

* Restore original use of nodeSet and cache only isolated nodes

* Add checks on size of isolatedNodesSet

* Add test of set data for isolated node

* Small fix


*A good pull request has the following information:*
- A reference to a related issue in your repository.
- A description of the changes proposed in the pull request.
- @mentions of the person or team responsible for reviewing proposed changes. ( optional ) 
